### PR TITLE
fix: update remaining 0.6.2 version references in tests to 0.7.12

### DIFF
--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -45,11 +45,11 @@ describe('Testing all functions in run file.', () => {
       (arch) => {
          jest.spyOn(os, 'type').mockReturnValue('Linux')
          const iamAuthLinuxUrl = util.format(
-            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_linux_%s',
+            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.12/aws-iam-authenticator_0.7.12_linux_%s',
             arch
          )
 
-         expect(getiamAuthDownloadURL('0.6.2', arch)).toBe(iamAuthLinuxUrl)
+         expect(getiamAuthDownloadURL('0.7.12', arch)).toBe(iamAuthLinuxUrl)
          expect(os.type).toBeCalled()
       }
    )
@@ -59,11 +59,11 @@ describe('Testing all functions in run file.', () => {
       (arch) => {
          jest.spyOn(os, 'type').mockReturnValue('Darwin')
          const iamAuthDarwinUrl = util.format(
-            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_darwin_%s',
+            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.12/aws-iam-authenticator_0.7.12_darwin_%s',
             arch
          )
 
-         expect(getiamAuthDownloadURL('0.6.2', arch)).toBe(iamAuthDarwinUrl)
+         expect(getiamAuthDownloadURL('0.7.12', arch)).toBe(iamAuthDarwinUrl)
          expect(os.type).toBeCalled()
       }
    )
@@ -74,10 +74,10 @@ describe('Testing all functions in run file.', () => {
          jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
 
          const iamAuthWindowsUrl = util.format(
-            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_windows_%s.exe',
+            'https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.12/aws-iam-authenticator_0.7.12_windows_%s.exe',
             arch
          )
-         expect(getiamAuthDownloadURL('0.6.2', arch)).toBe(iamAuthWindowsUrl)
+         expect(getiamAuthDownloadURL('0.7.12', arch)).toBe(iamAuthWindowsUrl)
          expect(os.type).toBeCalled()
       }
    )
@@ -86,9 +86,9 @@ describe('Testing all functions in run file.', () => {
       jest
          .spyOn(toolCache, 'downloadTool')
          .mockReturnValue(Promise.resolve('pathToTool'))
-      jest.spyOn(fs, 'readFileSync').mockReturnValue('{"tag_name":"v0.6.2"}')
+      jest.spyOn(fs, 'readFileSync').mockReturnValue('{"tag_name":"v0.7.12"}')
 
-      expect(await run.getStableiamAuthVersion()).toBe('0.6.2')
+      expect(await run.getStableiamAuthVersion()).toBe('0.7.12')
       expect(toolCache.downloadTool).toBeCalled()
       expect(fs.readFileSync).toBeCalledWith('pathToTool', 'utf8')
    })
@@ -124,10 +124,10 @@ describe('Testing all functions in run file.', () => {
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
       jest.spyOn(fs, 'chmodSync').mockImplementation(() => {})
 
-      expect(await run.downloadiamAuth('0.6.2')).toBe(
+      expect(await run.downloadiamAuth('0.7.12')).toBe(
          path.join('pathToCachedTool', 'aws-iam-authenticator.exe')
       )
-      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.6.2')
+      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.7.12')
       expect(toolCache.downloadTool).toBeCalled()
       expect(toolCache.cacheFile).toBeCalled()
       expect(os.type).toBeCalled()
@@ -143,10 +143,10 @@ describe('Testing all functions in run file.', () => {
          .spyOn(toolCache, 'downloadTool')
          .mockRejectedValue('Unable to download aws-iam-authenticator.')
 
-      await expect(run.downloadiamAuth('0.6.2')).rejects.toThrow(
+      await expect(run.downloadiamAuth('0.7.12')).rejects.toThrow(
          'DownloadiamAuthFailed'
       )
-      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.6.2')
+      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.7.12')
       expect(toolCache.downloadTool).toBeCalled()
    })
 
@@ -181,10 +181,10 @@ describe('Testing all functions in run file.', () => {
       jest.spyOn(fs, 'chmodSync').mockImplementation(() => {})
       jest.spyOn(toolCache, 'downloadTool')
 
-      expect(await run.downloadiamAuth('0.6.2')).toBe(
+      expect(await run.downloadiamAuth('0.7.12')).toBe(
          path.join('pathToCachedTool', 'aws-iam-authenticator.exe')
       )
-      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.6.2')
+      expect(toolCache.find).toBeCalledWith('aws-iam-authenticator', '0.7.12')
       expect(os.type).toBeCalled()
       expect(fs.chmodSync).toBeCalledWith(
          path.join('pathToCachedTool', 'aws-iam-authenticator.exe'),
@@ -194,7 +194,7 @@ describe('Testing all functions in run file.', () => {
    })
 
    test('run() - download specified version and set output', async () => {
-      jest.spyOn(core, 'getInput').mockReturnValue('0.6.2')
+      jest.spyOn(core, 'getInput').mockReturnValue('0.7.12')
       jest.spyOn(toolCache, 'find').mockReturnValue('pathToCachedTool')
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
       jest.spyOn(fs, 'chmodSync').mockImplementation()
@@ -216,7 +216,7 @@ describe('Testing all functions in run file.', () => {
       jest
          .spyOn(toolCache, 'downloadTool')
          .mockReturnValue(Promise.resolve('pathToTool'))
-      jest.spyOn(fs, 'readFileSync').mockReturnValue('{"tag_name":"v0.6.2"}')
+      jest.spyOn(fs, 'readFileSync').mockReturnValue('{"tag_name":"v0.7.12"}')
       jest.spyOn(toolCache, 'find').mockReturnValue('pathToCachedTool')
       jest.spyOn(os, 'type').mockReturnValue('Windows_NT')
       jest.spyOn(fs, 'chmodSync').mockImplementation()

--- a/src/run.ts
+++ b/src/run.ts
@@ -98,6 +98,4 @@ export async function downloadiamAuth(version: string): Promise<string> {
    return iamAuthPath
 }
 
-if (process.env.NODE_ENV !== 'test') {
-   run().catch(core.setFailed)
-}
+run().catch(core.setFailed)

--- a/src/run.ts
+++ b/src/run.ts
@@ -98,4 +98,6 @@ export async function downloadiamAuth(version: string): Promise<string> {
    return iamAuthPath
 }
 
-run().catch(core.setFailed)
+if (process.env.NODE_ENV !== 'test') {
+   run().catch(core.setFailed)
+}


### PR DESCRIPTION
## Summary

- Update all remaining hardcoded `0.6.2` version references in `src/run.test.ts` to `0.7.12`
- Covers URL assertions, `downloadiamAuth` calls, `getStableiamAuthVersion` mock data, and `run()` test inputs

## Test plan

- [x] All 23 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)